### PR TITLE
Correctly clean up the g_api_mutex for linux

### DIFF
--- a/src/os/linux/lnx_system.c
+++ b/src/os/linux/lnx_system.c
@@ -216,6 +216,7 @@ int os_mutex_delete(OS_MUTEX *p_mutex, const char *name)
 		{
 			shmdt(p_mutex);
 		}
+                free(p_mutex);
 	}
 	return rc;
 }

--- a/src/os/nvm_api/nvm_management.c
+++ b/src/os/nvm_api/nvm_management.c
@@ -121,13 +121,15 @@ NVM_API int nvm_init()
   if (EFI_SUCCESS != preferences_init())
   {
     NVDIMM_ERR("Failed to intialize preferences\n");
-    return NVM_ERR_UNKNOWN;
+    rc = NVM_ERR_UNKNOWN;
+    goto cleanup_mutex;
   }
 
   if (EFI_SUCCESS != NvmDimmDriverDriverEntryPoint(0, NULL))
   {
     NVDIMM_ERR("Nvm Dimm driver entry point failed.\n");
-    return NVM_ERR_UNKNOWN;
+    rc = NVM_ERR_UNKNOWN;
+    goto cleanup_mutex;
   }
 
   rc = os_check_admin_permissions();
@@ -141,6 +143,9 @@ NVM_API int nvm_init()
   }
   g_nvm_initialized = 1;
   return rc;
+cleanup_mutex:
+  os_mutex_delete(g_api_mutex, "nvm_api");
+  return rc;
 }
 
 NVM_API void nvm_uninit()
@@ -149,6 +154,11 @@ NVM_API void nvm_uninit()
   NvmDimmDriverDriverBindingStop(&gNvmDimmDriverDriverBinding, FakeBindHandle, 0, NULL);
   uninit_protocol_shell_parameters_protocol();
   preferences_uninit();
+
+  if (g_api_mutex) {
+    os_mutex_delete(g_api_mutex, "nvm_api");
+    g_api_mutex = NULL;
+  }
 }
 
 NVM_API void nvm_sync_lock_api()

--- a/src/os/nvm_api/nvm_management.h
+++ b/src/os/nvm_api/nvm_management.h
@@ -1181,6 +1181,11 @@ typedef union {
 */
 NVM_API int nvm_init();
 
+/**
+ * @brief  Clean up the library.
+ */
+NVM_API void nvm_uninit();
+
 /*
  * system.c
  */


### PR DESCRIPTION
Signed-off-by: Derek Chan <dchanman@google.com>

Also add nvm_uninit to nvm_management.h so that cleanup can be triggered externally. We were running into memory leaks when integrating into our system.