### PR TITLE
Fixed typo in command help

### DIFF
--- a/src/os/cli_cmds/DumpSupportCommand.c
+++ b/src/os/cli_cmds/DumpSupportCommand.c
@@ -28,7 +28,7 @@ struct Command DumpSupportCommandSyntax = {
   {                                                                 //!< properties
     { L"", L"", L"", FALSE, ValueOptional }
   },
-  L"Capture a snapshot of the system staet for support purposes",   //!< help
+  L"Capture a snapshot of the system state for support purposes",   //!< help
   DumpSupportCommand                                                //!< run function
 };
 


### PR DESCRIPTION
Found a typo in the help output produced by executing 'ipmctl' with no arguments.  The following

`Capture a snapshot of the system staet for support purposes`

should be

`Capture a snapshot of the system state for support purposes`

(staet -> state)

Issue is on line 31 of /src/os/cli_cmds/DumpSupportCommand.c