### PR TITLE
Non-root users should not see syntax errors for valid commands

### DIFF
--- a/DcpmPkg/cli/CommandParser.c
+++ b/DcpmPkg/cli/CommandParser.c
@@ -362,12 +362,14 @@ EFI_STATUS findVerb(UINTN *pStart, struct CommandInput *pInput, struct Command *
 #ifdef OS_BUILD
     if (g_basic_commands) {
       // This should be updated when there are other comamnds a non-root user can run
-      Print(L"A non-root user is restricted to run only version command\n");
+      Print(L"A non-root user is restricted to run only the 'version' command\n");
+      goto out;
     }
 #endif
     SetSyntaxError(CatSPrint(NULL, CLI_PARSER_ERR_VERB_EXPECTED, pInput->ppTokens[*pStart]));
   }
 
+out:
   NVDIMM_EXIT_I64(rc);
   return rc;
 }


### PR DESCRIPTION
```
$ ipmctl version
Intel(R) Optane(TM) DC Persistent Memory Command Line Interface Version 01.00.00.3279
```
A non-root user receives a syntax error when running valid sub-commands:

```
$ ipmctl show -dimm

A non-root user is restricted to run only version command
Syntax Error: First token must be a verb, 'show' is not a supported verb.
$
```


The suggested fix bypasses the syntax error and fixes the output so we now get:

```
$ ./ipmctl show -dimm

A non-root user is restricted to run only the 'version' command

$
```