### PR TITLE
Alpine linux compability.

### DIFF
--- a/src/os/linux/lnx_common.c
+++ b/src/os/linux/lnx_common.c
@@ -10,6 +10,7 @@
 
 
 #include "lnx_common.h"
+#include <sys/time.h>
 #include <string.h>
 #include <stdlib.h>
 

--- a/src/os/linux/lnx_system.c
+++ b/src/os/linux/lnx_system.c
@@ -35,6 +35,10 @@
                         // that is why the behavior is said to be undefined when proj_id is zero.
 #define SHM_PERM_FLG 0666 // permissions granted to the owner, group, and others.
 
+#ifndef ACCESSPERMS
+#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
+
 /*
  * Return the base path for the language catalog
  */
@@ -130,7 +134,7 @@ void os_create_thread(unsigned long long *p_thread_id, void *(*callback)(void *)
  */
 unsigned long long os_get_thread_id()
 {
-	return pthread_self();
+	return (unsigned long long)pthread_self();
 }
 
 /*


### PR DESCRIPTION
I had some issues with building the ipmctl on Alpine Linux.
This little fix helped me.

As a cAdvisor contributor ( https://github.com/google/cadvisor ), I want to add ipmctl to the docker image.
I tried to update the compilator, libs. 