### PR TITLE
Added info about Prometheus exporter based on libipmctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ ipmctl refers to the following interface components:
 * libipmctl: An Application Programming Interface (API) library for managing PMems.
 * ipmctl: A Command Line Interface (CLI) application for configuring and managing PMems from the command line.
 
+Also, metrics exporter for [Prometheus](https://prometheus.io/docs/introduction/overview/) based on libipmctl was provided. For more details take a look [here](https://github.com/intel/ipmctl-exporter)
+
 ## Workarounds
 
 ### Slow Firmware Updates


### PR DESCRIPTION
I would like to add additional information about the existing metrics exporter for Prometheus monitoring system based on libipmctl to the README.md file, just to inform everyone interested in such functionalities that it is already done.

Signed-off-by: Karol Zmijewski <karol.zmijewski@gmail.com>