### PR TITLE
Drop unused support for block aperture, fixing build with kernel 5.18

### DIFF
--- a/src/os/os.h
+++ b/src/os/os.h
@@ -66,8 +66,6 @@ struct driver_feature_flags
 
 struct nvm_driver_capabilities
 {
-	unsigned int block_sizes[MAX_NUMBER_OF_BLOCK_SIZES]; // in bytes
-	unsigned int num_block_sizes;
 	unsigned long long min_namespace_size; // in bytes
 	unsigned int namespace_memory_page_allocation_capable;
 	struct driver_feature_flags features;

--- a/src/os/win/win_system.c
+++ b/src/os/win/win_system.c
@@ -830,8 +830,6 @@ int os_get_driver_capabilities(struct nvm_driver_capabilities *p_capabilities)
 	memset(p_capabilities, 0, sizeof(struct nvm_driver_capabilities));
 
 	p_capabilities->min_namespace_size = BYTES_PER_GIB;
-	p_capabilities->num_block_sizes = 1;
-	p_capabilities->block_sizes[0] = 1;
 
 	p_capabilities->namespace_memory_page_allocation_capable = 0;
 	p_capabilities->features.get_platform_capabilities = 1;


### PR DESCRIPTION
With current userspace kernel headers, the build fails:

> /<<PKGBUILDDIR>>/src/os/linux/lnx_system.c: In function ‘get_supported_block_sizes’:
> /<<PKGBUILDDIR>>/src/os/linux/lnx_system.c:336:52: error: ‘ND_DEVICE_NAMESPACE_BLK’ undeclared (first use in this function); did you mean ‘ND_DEVICE_NAMESPACE_IO’?
>   336 |                                         (nstype == ND_DEVICE_NAMESPACE_BLK))
>       |                                                    ^~~~~~~~~~~~~~~~~~~~~~~
>       |                                                    ND_DEVICE_NAMESPACE_IO
> compilation terminated due to -Wfatal-errors.
> make[3]: *** [CMakeFiles/ipmctl_os_interface.dir/build.make:149: CMakeFiles/ipmctl_os_interface.dir/src/os/linux/lnx_system.c.o] Error 1

As block sizes we fetch have never been used for anything, let's just drop the query.