### PR TITLE
Isolates amd64 private functions to support compilation on non-amd64

### DIFF
--- a/src/os/efi_shim/lnx_efi_api.c
+++ b/src/os/efi_shim/lnx_efi_api.c
@@ -234,5 +234,5 @@ get_smbios_table(
 UINT32
 get_first_arg_from_va_list(VA_LIST args)
 {
-  return *((UINT32 *)(args[0].reg_save_area + args[0].gp_offset));
+  return VA_ARG(args, UINT32);
 }

--- a/src/os/linux/lnx_system.c
+++ b/src/os/linux/lnx_system.c
@@ -20,7 +20,6 @@
 #include <dlfcn.h>
 #include <stdio.h>
 #include <libgen.h>
-#include <cpuid.h>
 #include <sys/shm.h>
 #include <sys/types.h>
 #include <sys/ipc.h>
@@ -37,6 +36,10 @@
 
 #ifndef ACCESSPERMS
 #define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
+
+#ifdef __x86_64__
+#include <cpuid.h>
 #endif
 
 /*
@@ -509,6 +512,10 @@ int getCPUID(unsigned int *regs, int registerCount, int inputRequestType) {
   if (registerCount < 4) {
     return rc;
   }
+#ifdef __x86_64__
   __get_cpuid(inputRequestType, &(regs[0]), &(regs[1]), &(regs[2]), &(regs[3]));
+#else
+  memset(regs, 0, registerCount * sizeof(unsigned int));
+#endif
   return NVM_SUCCESS;
 }


### PR DESCRIPTION
Supports comilation on non-amd64 platforms. ARM64 can be compiled
successfully with this patch.

Signed-off-by: Chunsong Feng <fengchunsong@huawei.com>