### PR TITLE
sizeof('c')=4, not 1: fix overallocation

### DIFF
--- a/DcpmPkg/cli/LoadGoalCommand.c
+++ b/DcpmPkg/cli/LoadGoalCommand.c
@@ -368,7 +368,7 @@ ParseSourceDumpFile(
   }
 
   /** Prepare memory for end of string char **/
-  *pFileString = ReallocatePool(FileBufferSize, FileBufferSize + sizeof('\0'), pFileBuffer);
+  *pFileString = ReallocatePool(FileBufferSize, FileBufferSize + 1 /* NUL */, pFileBuffer);
   if (*pFileString == NULL) {
     ReturnCode = EFI_OUT_OF_RESOURCES;
     goto Finish;


### PR DESCRIPTION
As found by DCS `[^._]sizeof[ (]'.{1,2}' filetype:c`

Ref: https://paste.sr.ht/~nabijaczleweli/6ee9ccf301a2651afb693bff46e3671d3f7cdd89
Ref: https://101010.pl/@nabijaczleweli/111587138076843793